### PR TITLE
allow forcing release without changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,4 @@
 #
 
 * @open-telemetry/php-approvers
+* @brettmc @bobstrecansky @pdelewski

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,5 +8,5 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/php-approvers
 * @brettmc @bobstrecansky @pdelewski
+# note that open-telemetry/php-approvers does not exist in this organization

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ Manual steps:
 1. copy/paste XML into `package.xml`
 2. open in IDE to check for/fix formatting and invalid XML (invalid chars should have been converted)
 3. update `php_opentelemetry.h` version info to match new version# (look for `PHP_OPENTELEMETRY_VERSION`)
-4. pear package-validate
-5. pear package (creates `opentelemetry-<version>.tar.gz`)
-6. upload .tar.gz to pecl
-7. verify (install via pecl)
-8. commit changes (`package.xml` + `php_opentelemetry.h`) back to [opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
-9. tag with new version#
+4. in opentelemetry-php-instrumentation checkout, run `docker compose run debian bash`, then:
+  * pear package-validate
+  * pear package (creates `opentelemetry-<version>.tar.gz`)
+5. submit a PR (`package.xml` + `php_opentelemetry.h`) back to [opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
+6. get approval and merge PR
+7. tag next release, using auto-generated release notes (optionally, remove the "release prep" line item)
+8. upload .tar.gz to pecl: https://pecl.php.net/release-upload.php
+9. verify (install via pecl)

--- a/src/Console/Command/Release/ReleaseCommand.php
+++ b/src/Console/Command/Release/ReleaseCommand.php
@@ -30,6 +30,7 @@ class ReleaseCommand extends AbstractReleaseCommand
     private Parser $parser;
     private string $source_branch;
     private bool $dry_run;
+    private bool $force;
 
     protected function configure(): void
     {
@@ -40,6 +41,7 @@ class ReleaseCommand extends AbstractReleaseCommand
             ->addOption('token', ['t'], InputOption::VALUE_OPTIONAL, 'github token')
             ->addOption('branch', null, InputOption::VALUE_OPTIONAL, 'branch to tag off (default: main)')
             ->addOption('repo', ['r'], InputOption::VALUE_OPTIONAL, 'repo to handle (core, contrib)')
+            ->addOption('force', ['f'], InputOption::VALUE_NONE, 'force new releases even if no changes')
         ;
     }
     protected function interact(InputInterface $input, OutputInterface $output)
@@ -60,6 +62,7 @@ class ReleaseCommand extends AbstractReleaseCommand
         $this->token = $input->getOption('token');
         $this->source_branch = $input->getOption('branch') ?? 'main';
         $this->dry_run = $input->getOption('dry-run');
+        $this->force = $input->getOption('force');
         $source = $input->getOption('repo');
         if ($source && !array_key_exists($source, self::AVAILABLE_REPOS)) {
             $options = implode(',', array_keys(self::AVAILABLE_REPOS));
@@ -221,7 +224,7 @@ class ReleaseCommand extends AbstractReleaseCommand
     private function publish_repositories(array $repositories): void
     {
         foreach ($repositories as $repo) {
-            if (count($repo->commits) === 0) {
+            if (count($repo->commits) === 0 && !$this->force) {
                 $this->output->isVerbose() && $this->output->writeln("<info>[SKIP] {$repo->downstream} (no new commits)</info>");
 
                 continue;


### PR DESCRIPTION
when we need to release GA, we may need to create new releases without code changes. This adds a --force option to the release:run command to achieve this.