### PR TITLE
adding a pecl tag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ Once all the info has been gathered, it will iterate over each repo with unrelea
 * generate release notes
 * create the release (unless `--dry-run` was specified)
 
-### TODO
-* in the future, we may have multiple release branches (`1.x`, `2.x`) (may need to redefine "latest" to find latest in a given line?)
-* finding changes dated after the last release is flaky if you do weird things like recreate releases... a better way might be "find changes in branch <source> not in tag <latest>"?
-
 ## PECL release tool
 
 A tool to fetch and update package.xml, for a new version of the opentelemetry extension on PECL.
@@ -78,11 +74,10 @@ Manual steps:
 1. copy/paste XML into `package.xml`
 2. open in IDE to check for/fix formatting and invalid XML (invalid chars should have been converted)
 3. update `php_opentelemetry.h` version info to match new version# (look for `PHP_OPENTELEMETRY_VERSION`)
-4. in opentelemetry-php-instrumentation checkout, run `docker compose run debian bash`, then:
-  * pear package-validate
-  * pear package (creates `opentelemetry-<version>.tar.gz`)
-5. submit a PR (`package.xml` + `php_opentelemetry.h`) back to [opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
-6. get approval and merge PR
-7. tag next release, using auto-generated release notes (optionally, remove the "release prep" line item)
-8. upload .tar.gz to pecl: https://pecl.php.net/release-upload.php
-9. verify (install via pecl)
+4. submit a PR (`package.xml` + `php_opentelemetry.h`) back to [opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
+5. get approval and merge PR
+6. tag next release: `bin/otel tag:pecl`
+7. wait for github workflow to run, eyeball it, then publish it
+8. download and unzip the `opentelemetry-pecl` artifact from the release (containing `opentelemetry-<version>.tar.gz`)
+9. upload `opentelemetry-<version>.tar.gz` to pecl: https://pecl.php.net/release-upload.php
+10. verify (install via pecl)

--- a/src/Console/Application/Application.php
+++ b/src/Console/Application/Application.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\DevTools\Console\Application;
 use OpenTelemetry\DevTools\Console\Command\Packages\ValidateInstallationCommand;
 use OpenTelemetry\DevTools\Console\Command\Packages\ValidatePackagesCommand;
 use OpenTelemetry\DevTools\Console\Command\Release\PeclCommand;
+use OpenTelemetry\DevTools\Console\Command\Release\PeclTagCommand;
 use OpenTelemetry\DevTools\Console\Command\Release\ReleaseCommand;
 use OpenTelemetry\DevTools\Package\Composer\MultiRepositoryInfoResolver;
 use OpenTelemetry\DevTools\Package\Composer\PackageAttributeResolverFactory;
@@ -38,6 +39,7 @@ class Application extends BaseApplication
             ),
             new ReleaseCommand(),
             new PeclCommand(),
+            new PeclTagCommand(),
         ]);
     }
 }

--- a/src/Console/Command/Release/AbstractReleaseCommand.php
+++ b/src/Console/Command/Release/AbstractReleaseCommand.php
@@ -54,7 +54,7 @@ abstract class AbstractReleaseCommand extends BaseCommand
 
         $response = $this->fetch($release_url);
         if ($response->getStatusCode() === 404) {
-            $this->output->writeln('<error>No latest release found</error>');
+            $this->output->writeln("<info>[{$repository->downstream}] No latest release found</info>");
 
             return null;
         }

--- a/src/Console/Command/Release/AbstractReleaseCommand.php
+++ b/src/Console/Command/Release/AbstractReleaseCommand.php
@@ -28,6 +28,7 @@ abstract class AbstractReleaseCommand extends BaseCommand
         if ($this->token) {
             $headers['Authorization'] ="Bearer {$this->token}";
         }
+
         return $headers;
     }
 
@@ -149,6 +150,7 @@ abstract class AbstractReleaseCommand extends BaseCommand
         $response = $this->fetch($refs_url);
         if ($response->getStatusCode() !== 200) {
             $this->output->isDebug() && $this->output->writeln($response->getBody()->getContents());
+
             throw new \Exception("Error {$response->getStatusCode()} retrieving branch refs for {$branch}");
         }
         $json = json_decode($response->getBody()->getContents());

--- a/src/Console/Command/Release/PeclTagCommand.php
+++ b/src/Console/Command/Release/PeclTagCommand.php
@@ -43,6 +43,9 @@ class PeclTagCommand extends AbstractReleaseCommand
         }
     }
 
+    /**
+     * @psalm-suppress PossiblyNullPropertyFetch
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->token = $input->getOption('token');
@@ -64,7 +67,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         $helper = new QuestionHelper();
         $newVersion = $helper->ask($this->input, $this->output, $question);
         if (!$newVersion) {
-            $this->output->writeln("<info>[SKIP] not going to tag</info>");
+            $this->output->writeln('<info>[SKIP] not going to tag</info>');
 
             return Command::SUCCESS;
         }
@@ -84,7 +87,7 @@ class PeclTagCommand extends AbstractReleaseCommand
             'tag' => $tag,
             'message' => $message,
             'object' => $sha,
-            'type' => 'commit'
+            'type' => 'commit',
         ], JSON_UNESCAPED_SLASHES);
         if ($this->dry_run) {
             $this->output->writeln("[DRY-RUN] POST {$url}");
@@ -94,6 +97,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         $response = $this->post($url, $body);
         if ($response->getStatusCode() !== 201) {
             $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
+
             return;
         }
         $json = json_decode($response->getBody()->getContents());
@@ -111,6 +115,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         ], JSON_UNESCAPED_SLASHES);
         if ($this->dry_run) {
             $this->output->writeln("[DRY-RUN] POST {$url} {$body}");
+
             return;
         }
         $response = $this->post($url, $body);

--- a/src/Console/Command/Release/PeclTagCommand.php
+++ b/src/Console/Command/Release/PeclTagCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\DevTools\Console\Command\Release;
+
+use Http\Discovery\Psr18ClientDiscovery;
+use OpenTelemetry\DevTools\Console\Release\Project;
+use OpenTelemetry\DevTools\Console\Release\Repository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class PeclTagCommand extends AbstractReleaseCommand
+{
+    private const REPOSITORY = 'open-telemetry/opentelemetry-php-instrumentation';
+    private bool $dry_run;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('tag:pecl')
+            ->setDescription('Create a new tag in the auto-instrumentation repository')
+            ->addOption('branch', ['b'], InputOption::VALUE_OPTIONAL, 'branch to tag from', 'main')
+            ->addOption('token', ['t'], InputOption::VALUE_OPTIONAL, 'github token')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'dry-run')
+        ;
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('token')) {
+            $token = getenv('GITHUB_TOKEN');
+            if ($token !== false) {
+                $input->setOption('token', $token);
+            }
+        }
+        if (!$input->getOption('token')) {
+            throw new \RuntimeException('No github token provided (via --token or GITHUB_TOKEN env)');
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->token = $input->getOption('token');
+        $branch = $input->getOption('branch');
+        $this->dry_run = $input->getOption('dry-run');
+        $this->client = Psr18ClientDiscovery::find();
+        $this->registerInputAndOutput($input, $output);
+        $project = new Project(self::REPOSITORY);
+        $repository = new Repository();
+        $repository->downstream = $project;
+        $repository->upstream = $project;
+
+        $sha = $this->get_sha_for_branch($repository, $branch);
+        $repository->latestRelease = $this->get_latest_release($repository);
+        $prev = $repository->latestRelease->version;
+
+        $question = new Question("<question>Latest={$prev}, enter new tag (blank to skip):</question>", null);
+
+        $helper = new QuestionHelper();
+        $newVersion = $helper->ask($this->input, $this->output, $question);
+        if (!$newVersion) {
+            $this->output->writeln("<info>[SKIP] not going to tag</info>");
+
+            return Command::SUCCESS;
+        }
+        $this->output->writeln("[INFO] Creating tag {$newVersion} from branch {$branch}");
+        $this->create_tag($repository, $sha, $newVersion, "Tagging {$newVersion}");
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Create an annotated tag
+     */
+    protected function create_tag(Repository $repository, string $sha, string $tag, string $message): void
+    {
+        $url = "https://api.github.com/repos/{$repository->upstream}/git/tags";
+        $body = json_encode([
+            'tag' => $tag,
+            'message' => $message,
+            'object' => $sha,
+            'type' => 'commit'
+        ], JSON_UNESCAPED_SLASHES);
+        if ($this->dry_run) {
+            $this->output->writeln("[DRY-RUN] POST {$url}");
+
+            return;
+        }
+        $response = $this->post($url, $body);
+        if ($response->getStatusCode() !== 201) {
+            $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
+            return;
+        }
+        $json = json_decode($response->getBody()->getContents());
+        $this->output->writeln("<info>[CREATED] {$repository->upstream} $tag: </info> {$json->url}");
+
+        $this->create_reference($repository, $json->sha, $json->tag);
+    }
+
+    protected function create_reference(Repository $repository, string $sha, string $tag): void
+    {
+        $url = "https://api.github.com/repos/{$repository->upstream}/git/refs";
+        $body = json_encode([
+            'ref' => "refs/tags/{$tag}",
+            'sha' => $sha,
+        ], JSON_UNESCAPED_SLASHES);
+        if ($this->dry_run) {
+            $this->output->writeln("[DRY-RUN] POST {$url} {$body}");
+            return;
+        }
+        $response = $this->post($url, $body);
+        if ($response->getStatusCode() !== 201) {
+            $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
+        } else {
+            $json = json_decode($response->getBody()->getContents());
+            $this->output->writeln("<info>[CREATED] {$repository->upstream} $tag: </info> {$json->url}");
+        }
+    }
+}

--- a/src/Console/Command/Release/ReleaseCommand.php
+++ b/src/Console/Command/Release/ReleaseCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\DevTools\Console\Command\Release;
 
 use Http\Discovery\Psr18ClientDiscovery;
-use Nyholm\Psr7\Request;
 use OpenTelemetry\DevTools\Console\Release\Commit;
 use OpenTelemetry\DevTools\Console\Release\Diff;
 use OpenTelemetry\DevTools\Console\Release\Project;


### PR DESCRIPTION
The extension's release process has changed slightly. Now, binaries are generated via workflow. When a tag is created, a new release is created from workflow, and binaries are added to the release. Since you can't create a tag from github GUI, create a command here which will do it for us, and update our release documentation accordingly.