### PR TITLE
update doc for pecl:tag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ A tool to find unreleased changes for OpenTelemetry, create new releases with re
 You need to be an administrator/owner of [opentelemetry-php](https://github.com/opentelemetry-php) to actually create releases. A lower-privileged account
 should be able to do everything else, but will fail if you try to create a release.
 
-You need to [create a fine-grained github access token](https://github.com/settings/personal-access-tokens/new) with:
+You need to [create a fine-grained github access token](https://github.com/settings/personal-access-tokens/new) to be able to create a release.
+
+For everything under `opentelemetry-php` (almost everything, ie the gitsplit destination):
 * resource owner: `opentelemetry-php`
 * repository access: `all repositories`
+* permissions: `contents:read-and-write`
+
+For `opentelemetry-php-instrumentation` (the extension):
+* resouce owner: `open-telemetry`
+* repository access: (only selected) `open-telemetry/opentelemetry-php-instrumentation`
 * permissions: `contents:read-and-write`
 
 You can provide the token either via the `GITHUB_TOKEN` env var (preferred), or the `--token=` CLI option.

--- a/src/Console/Command/Release/AbstractReleaseCommand.php
+++ b/src/Console/Command/Release/AbstractReleaseCommand.php
@@ -43,7 +43,8 @@ abstract class AbstractReleaseCommand extends BaseCommand
     protected function post(string $url, string $body): ResponseInterface
     {
         $request = new Request('POST', $url, $this->headers(), $body);
-        $this->output->isVeryVerbose() && $this->output->writeln("[HTTP] POST {$url}");
+        $this->output->isVerbose() && $this->output->writeln("[HTTP] POST {$url}");
+        $this->output->isVeryVerbose() && $this->output->writeln("[HTTP body] {$body}");
 
         return $this->client->sendRequest($request);
     }

--- a/src/Console/Command/Release/PeclTagCommand.php
+++ b/src/Console/Command/Release/PeclTagCommand.php
@@ -97,7 +97,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         $response = $this->post($url, $body);
         if ($response->getStatusCode() !== 201) {
             $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
-            $this->output->writeln("[HELP] X-Accepted-GitHub-Permissions: " . $response->getHeaderLine('X-Accepted-GitHub-Permissions'));
+            $this->output->writeln('[HELP] X-Accepted-GitHub-Permissions: ' . $response->getHeaderLine('X-Accepted-GitHub-Permissions'));
 
             return;
         }

--- a/src/Console/Command/Release/PeclTagCommand.php
+++ b/src/Console/Command/Release/PeclTagCommand.php
@@ -97,6 +97,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         $response = $this->post($url, $body);
         if ($response->getStatusCode() !== 201) {
             $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
+            $this->output->writeln("[HELP] X-Accepted-GitHub-Permissions: " . $response->getHeaderLine('X-Accepted-GitHub-Permissions'));
 
             return;
         }


### PR DESCRIPTION
pecl:tag requires different permissions than other commands. document them, and add some extra output when running in verbose mode