### PR TITLE
update doc for pecl:tag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ A tool to find unreleased changes for OpenTelemetry, create new releases with re
 You need to be an administrator/owner of [opentelemetry-php](https://github.com/opentelemetry-php) to actually create releases. A lower-privileged account
 should be able to do everything else, but will fail if you try to create a release.
 
-You need to [create a fine-grained github access token](https://github.com/settings/personal-access-tokens/new) with:
+You need to [create a fine-grained github access token](https://github.com/settings/personal-access-tokens/new) to be able to create a release.
+
+For everything under `opentelemetry-php` (almost everything, ie the gitsplit destination):
 * resource owner: `opentelemetry-php`
 * repository access: `all repositories`
+* permissions: `contents:read-and-write`
+
+For `opentelemetry-php-instrumentation` (the extension):
+* resouce owner: `open-telemetry`
+* repository access: (only selected) `open-telemetry/opentelemetry-php-instrumentation`
 * permissions: `contents:read-and-write`
 
 You can provide the token either via the `GITHUB_TOKEN` env var (preferred), or the `--token=` CLI option.
@@ -51,6 +58,7 @@ Once all the info has been gathered, it will iterate over each repo with unrelea
 
 ## PECL release tool
 
+### Generate updated `package.xml`
 A tool to fetch and update package.xml, for a new version of the opentelemetry extension on PECL.
 
 ```shell
@@ -77,7 +85,7 @@ Manual steps:
 4. submit a PR (`package.xml` + `php_opentelemetry.h`) back to [opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
 5. get approval and merge PR
 6. tag next release: `bin/otel tag:pecl`
-7. wait for github workflow to run, eyeball it, then publish it
+7. wait for github workflow to run to completion. it will create a draft release: check that it looks ok, then publish it
 8. download and unzip the `opentelemetry-pecl` artifact from the release (containing `opentelemetry-<version>.tar.gz`)
 9. upload `opentelemetry-<version>.tar.gz` to pecl: https://pecl.php.net/release-upload.php
 10. verify (install via pecl)

--- a/src/Console/Command/Release/AbstractReleaseCommand.php
+++ b/src/Console/Command/Release/AbstractReleaseCommand.php
@@ -43,7 +43,8 @@ abstract class AbstractReleaseCommand extends BaseCommand
     protected function post(string $url, string $body): ResponseInterface
     {
         $request = new Request('POST', $url, $this->headers(), $body);
-        $this->output->isVeryVerbose() && $this->output->writeln("[HTTP] POST {$url}");
+        $this->output->isVerbose() && $this->output->writeln("[HTTP] POST {$url}");
+        $this->output->isVeryVerbose() && $this->output->writeln("[HTTP body] {$body}");
 
         return $this->client->sendRequest($request);
     }

--- a/src/Console/Command/Release/PeclCommand.php
+++ b/src/Console/Command/Release/PeclCommand.php
@@ -7,7 +7,6 @@ namespace OpenTelemetry\DevTools\Console\Command\Release;
 use DOMDocument;
 use Exception;
 use Http\Discovery\Psr18ClientDiscovery;
-use OpenTelemetry\DevTools\Console\Release\Commit;
 use OpenTelemetry\DevTools\Console\Release\Project;
 use OpenTelemetry\DevTools\Console\Release\Repository;
 use SimpleXMLElement;
@@ -20,7 +19,9 @@ use Symfony\Component\Console\Question\Question;
 
 class PeclCommand extends AbstractReleaseCommand
 {
-    private const REPOSITORY = 'open-telemetry/opentelemetry-php-instrumentation';
+    private const OWNER = 'open-telemetry';
+    private const REPO = 'opentelemetry-php-instrumentation';
+    private const REPOSITORY = self::OWNER . '/' . self::REPO;
     private bool $force;
 
     protected function configure(): void
@@ -100,7 +101,7 @@ class PeclCommand extends AbstractReleaseCommand
                 'release' => $newVersion,
                 'api' => '1.0',
             ],
-            'notes' => "opentelemetry {$newVersion}" . PHP_EOL . $this->format_notes($repository->commits),
+            'notes' => $this->format_notes($newVersion),
         ];
         $this->output->writeln($this->convertPackageXml($xml, $release));
     }
@@ -136,19 +137,8 @@ class PeclCommand extends AbstractReleaseCommand
         return $pretty->saveXML();
     }
 
-    /**
-     * @param array<Commit> $commits
-     * @return string
-     */
-    private function format_notes(array $commits): string
+    private function format_notes(string $version): string
     {
-        $notes = '';
-        foreach ($commits as $commit) {
-            //only first line of commit message
-            $header = strtok($commit->message, PHP_EOL);
-            $notes .= "* {$header}" . PHP_EOL;
-        }
-
-        return $notes;
+        return sprintf('See https://github.com/%s/%s/releases/tag/%s', self::OWNER, self::REPO, $version);
     }
 }

--- a/src/Console/Command/Release/PeclTagCommand.php
+++ b/src/Console/Command/Release/PeclTagCommand.php
@@ -97,6 +97,7 @@ class PeclTagCommand extends AbstractReleaseCommand
         $response = $this->post($url, $body);
         if ($response->getStatusCode() !== 201) {
             $this->output->writeln("<error>[ERROR] ({$response->getStatusCode()}) {$response->getBody()->getContents()}</error>");
+            $this->output->writeln('[HELP] X-Accepted-GitHub-Permissions: ' . $response->getHeaderLine('X-Accepted-GitHub-Permissions'));
 
             return;
         }


### PR DESCRIPTION
pecl:tag requires different permissions than other commands. document them, and add some extra output when running in verbose mode